### PR TITLE
Update Go to v1.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/test-network-function/l2discovery-exports
 
-go 1.20
+go 1.21


### PR DESCRIPTION
https://go.dev/doc/go1.21

Related to: https://github.com/test-network-function/cnf-certification-test/pull/1344